### PR TITLE
Fix header color, add responsive layout, reload on close

### DIFF
--- a/script.js
+++ b/script.js
@@ -36,14 +36,5 @@ images.forEach(img => {
 });
 
 closeBtn.addEventListener('click', () => {
-  if (!currentImg) return;
-  images.forEach(i => {
-    i.classList.remove('fade-out-other', 'hidden', 'expanded', 'dim-image');
-  });
-  details.classList.add('hidden');
-  descriptionDiv.classList.remove('fade-in-text');
-  closeBtn.classList.add('hidden');
-  body.classList.remove('fade-bg');
-  body.appendChild(closeBtn);
-  currentImg = null;
+  window.location.href = 'index.html';
 });

--- a/style.css
+++ b/style.css
@@ -7,7 +7,7 @@ body {
 }
 header {
   padding: 20px;
-  background: #fff;
+  background: #ccc;
 }
 .gallery {
   display: flex;
@@ -114,4 +114,17 @@ header {
   position: absolute;
   top: 5px;
   right: 5px;
+}
+
+/* Responsive styles */
+@media (max-width: 600px) {
+  .gallery {
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .image-container {
+    width: 90%;
+    max-width: 400px;
+  }
 }


### PR DESCRIPTION
## Summary
- make header background grey
- add responsive styles for small screens so images resize
- reload home screen when user taps close button

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6873423af5b48328a56d4276d48b8df0