### PR TITLE
Adjust overlay for mobile

### DIFF
--- a/script.js
+++ b/script.js
@@ -3,6 +3,7 @@ const details = document.querySelector('.details');
 const descriptionDiv = document.querySelector('.description');
 const closeBtn = document.querySelector('.close-btn');
 const body = document.body;
+const header = document.querySelector('header');
 let currentImg = null;
 
 images.forEach(img => {
@@ -24,6 +25,7 @@ images.forEach(img => {
       img.appendChild(closeBtn);
       closeBtn.classList.remove('hidden');
       body.classList.add('fade-bg');
+      header.classList.add('hidden');
       setTimeout(() => {
         img.classList.add('dim-image');
         const desc = img.getAttribute('data-desc');

--- a/style.css
+++ b/style.css
@@ -127,4 +127,9 @@ header {
     width: 90%;
     max-width: 400px;
   }
+
+  .expanded {
+    transform: translate(-50%, -50%) scale(1);
+    animation: none;
+  }
 }


### PR DESCRIPTION
## Summary
- hide the header when showing the zoomed image
- avoid zoom animation on small screens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6873eb51d200832886cfd3480518d568