### PR TITLE
Improve mobile layout and close button

### DIFF
--- a/style.css
+++ b/style.css
@@ -14,6 +14,7 @@ header {
   justify-content: center;
   gap: 20px;
   margin: 20px;
+  flex-wrap: wrap;
 }
 .image-container {
   position: relative;
@@ -54,7 +55,8 @@ header {
   transform: translate(-50%, -50%);
   z-index: 20;
   margin: 0;
-  width: 100%;
+  width: 90%;
+  max-width: 100%;
 }
 .hidden {
   display: none;
@@ -73,7 +75,7 @@ header {
   position: fixed;
   top: 10px;
   right: 10px;
-  z-index: 20;
+  z-index: 30;
   font-size: 24px;
   width: 40px;
   height: 40px;
@@ -110,28 +112,34 @@ header {
   font-size: 1.2em;
   font-weight: bold;
   text-align: center;
+  word-break: break-word;
+  overflow-wrap: anywhere;
 }
 .image-container .close-btn {
   position: absolute;
   top: 5px;
   right: 5px;
+  z-index: 30;
 }
 
 /* Responsive styles */
 @media (max-width: 600px) {
   .gallery {
-    flex-direction: column;
-    align-items: center;
+    flex-direction: row;
+    justify-content: space-between;
+    gap: 5px;
   }
 
   .image-container {
-    width: 90%;
-    max-width: 400px;
+    width: 32%;
+    max-width: none;
   }
 
   .expanded {
     transform: translate(-50%, -50%) scale(1);
     animation: none;
+    max-width: 100vw;
+    max-height: 100vh;
   }
 
   .details {


### PR DESCRIPTION
## Summary
- allow wrapping of gallery images
- prevent text overflow in description and details overlay
- keep images within viewport on mobile
- ensure close button is visible and clickable

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68748818fbac8328b591a959c09f68c5