### PR TITLE
Restore layout and unify gallery ratio

### DIFF
--- a/style.css
+++ b/style.css
@@ -19,15 +19,15 @@ header {
 .image-container {
   position: relative;
   overflow: hidden;
-  width: 528px;
-  height: 682px;
+  width: 300px;
+  aspect-ratio: 528 / 682;
   animation: slideIn 1s ease;
   cursor: pointer;
 }
 .image-container img {
-  width: auto;
-  height: auto;
-  object-fit: none;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
 }
 @keyframes slideIn {
   from { transform: translateX(100%); opacity: 0; }
@@ -138,8 +138,8 @@ header {
   }
 
   .image-container {
-    width: 528px;
-    height: 682px;
+    width: 32%;
+    aspect-ratio: 528 / 682;
     max-width: none;
   }
 


### PR DESCRIPTION
## Summary
- revert change that forced large uniform image sizes
- keep consistent aspect ratio so images line up again

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687cf4c9ab4c83288ab00154f92cd52a