### PR TITLE
Modify button and close icon sizes

### DIFF
--- a/style.css
+++ b/style.css
@@ -76,6 +76,7 @@ header {
   text-decoration: none;
   border-radius: 4px;
   width: 40%;
+  font-size: 10px;
 }
 
 .close-btn {
@@ -164,5 +165,15 @@ header {
   .description {
     font-size: 7px;
     word-break: break-word;
+  }
+
+  .more-button {
+    font-size: 7px;
+  }
+
+  .close-btn {
+    font-size: 10px;
+    width: 20px;
+    height: 20px;
   }
 }


### PR DESCRIPTION
## Summary
- match the "詳しくはこちら" button font size with description text
- reduce the close button size on mobile

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687da3b2d9488328bfb86821e252e011