### PR TITLE
Fix mobile details scroll and button link

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,7 +69,7 @@
 
   <section class="details hidden">
     <div class="description"></div>
-    <a href="https://example.com" class="more-button">詳しくはこちら</a>
+    <a href="index.html" class="more-button">詳しくはこちら</a>
   </section>
 
   <div class="close-btn hidden">&times;</div>

--- a/style.css
+++ b/style.css
@@ -63,6 +63,8 @@ header {
   margin: 0;
   width: 66%;
   max-width: 100%;
+  overflow-y: auto;
+  max-height: 80vh;
 }
 .hidden {
   display: none;
@@ -160,6 +162,8 @@ header {
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
+    overflow-y: auto;
+    max-height: 70vh;
   }
 
   .description {


### PR DESCRIPTION
## Summary
- make text section scrollable on mobile by limiting max-height
- change "詳しくはこちら" button to return to top page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687da5ba9b248328ada9d8c1b2b482c8