### PR TITLE
Center description text on desktop

### DIFF
--- a/style.css
+++ b/style.css
@@ -130,7 +130,7 @@ header {
 .description {
   font-size: 10px;
   font-weight: bold;
-  text-align: left;
+  text-align: center;
   word-break: break-word;
   overflow-wrap: anywhere;
 }


### PR DESCRIPTION
## Summary
- adjust `.description` style so that description text is center-aligned on desktop view

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687fc77979cc8328a797eb935beb6604