### PR TITLE
Center detail text on desktop

### DIFF
--- a/style.css
+++ b/style.css
@@ -65,6 +65,10 @@ header {
   margin: 0;
   padding: 10px;
   box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
 }
@@ -172,6 +176,7 @@ header {
     transform: none;
     padding: 10px;
     box-sizing: border-box;
+    justify-content: flex-start;
     overflow-y: auto;
     -webkit-overflow-scrolling: touch;
   }


### PR DESCRIPTION
## Summary
- center the detail overlay text for desktop screens
- keep mobile detail overlay aligned at top

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687fca6c499883289f2c53c6b3c9bd4d