### PR TITLE
Add intro overlay animation

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,8 +6,12 @@
   <title>感じあう神経整体</title>
   <link rel="stylesheet" href="style.css">
 </head>
-<body>
-  <header>
+  <body>
+    <div id="intro-overlay">
+      <p id="intro-text1">からだの痛みで悩んでいるみなさまへ</p>
+      <p id="intro-text2">今のあなたの状態を選んでください</p>
+    </div>
+    <header>
     <h1>感じあう神経整体</h1>
     <p class="subtext">今のあなたの状態を３つの絵からクリックして選んでみてください！</p>
   </header>

--- a/script.js
+++ b/script.js
@@ -5,6 +5,26 @@ const closeBtn = document.querySelector('.close-btn');
 const body = document.body;
 const header = document.querySelector('header');
 const moreButton = document.querySelector('.more-button');
+const introOverlay = document.getElementById('intro-overlay');
+const introText1 = document.getElementById('intro-text1');
+const introText2 = document.getElementById('intro-text2');
+
+window.addEventListener('DOMContentLoaded', () => {
+  header.classList.add('hidden');
+  setTimeout(() => {
+    introText1.classList.add('show-text');
+  }, 100);
+  setTimeout(() => {
+    introText2.classList.add('show-text');
+  }, 6000);
+  setTimeout(() => {
+    introOverlay.classList.add('fade-out-overlay');
+  }, 13000);
+  setTimeout(() => {
+    introOverlay.remove();
+    header.classList.remove('hidden');
+  }, 18000);
+});
 
 // Change button text on mobile
 if (window.matchMedia('(max-width: 600px)').matches) {

--- a/style.css
+++ b/style.css
@@ -146,6 +146,46 @@ header {
   z-index: 30;
 }
 
+#intro-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(128, 128, 128, 1);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+}
+
+#intro-overlay p {
+  opacity: 0;
+  margin: 10px 0;
+  color: #000;
+  font-size: 20px;
+  font-weight: bold;
+}
+
+.show-text {
+  animation: fadeInSlow 5s forwards;
+}
+
+.fade-out-overlay {
+  animation: fadeOutSlow 5s forwards;
+}
+
+@keyframes fadeInSlow {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes fadeOutSlow {
+  from { opacity: 1; }
+  to { opacity: 0; }
+}
+
 /* Responsive styles */
 @media (max-width: 600px) {
   .gallery {


### PR DESCRIPTION
## Summary
- add an intro overlay with two messages
- style the overlay and create fade animations
- control intro display timing with JavaScript

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6881dafa42808328a7218dd9a74fefa1