### PR TITLE
Enable early image selection

### DIFF
--- a/script.js
+++ b/script.js
@@ -20,6 +20,9 @@ window.addEventListener('DOMContentLoaded', () => {
     introOverlay.classList.add('fade-out-overlay');
     introText1.classList.add('fade-out-text');
     introText2.classList.add('fade-out-text');
+    setTimeout(() => {
+      introOverlay.style.pointerEvents = 'none';
+    }, 1000);
   }, 7100);
   setTimeout(() => {
     introOverlay.remove();


### PR DESCRIPTION
## Summary
- allow clicking images 1 second after intro fade begins

## Testing
- `node -c script.js`


------
https://chatgpt.com/codex/tasks/task_e_6881e4b87cbc832890b1406ab6dea07d