### PR TITLE
Add intro card animation

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
       <div id="intro-overlay">
         <p id="intro-text1">今のあなたは、どんな状態ですか？</p>
         <p id="intro-text2">手を当ててみて下さい</p>
+        <img id="intro-card" src="images/card.png" alt="card">
       </div>
     <header>
     <h1>感じあう神経整体</h1>

--- a/script.js
+++ b/script.js
@@ -8,6 +8,7 @@ const moreButton = document.querySelector('.more-button');
 const introOverlay = document.getElementById('intro-overlay');
 const introText1 = document.getElementById('intro-text1');
 const introText2 = document.getElementById('intro-text2');
+const introCard = document.getElementById('intro-card');
 
 window.addEventListener('DOMContentLoaded', () => {
   setTimeout(() => {
@@ -17,16 +18,21 @@ window.addEventListener('DOMContentLoaded', () => {
     introText2.classList.add('show-text');
   }, 3100);
   setTimeout(() => {
-    introOverlay.classList.add('fade-out-overlay');
-    introText1.classList.add('fade-out-text');
-    introText2.classList.add('fade-out-text');
-    setTimeout(() => {
-      introOverlay.style.pointerEvents = 'none';
-    }, 1000);
-  }, 7100);
+    introCard.classList.add('show-card');
+  }, 5100);
+});
+
+introCard.addEventListener('click', () => {
+  introOverlay.classList.add('fade-out-overlay');
+  introText1.classList.add('fade-out-text');
+  introText2.classList.add('fade-out-text');
+  introCard.classList.add('fade-out-text');
+  setTimeout(() => {
+    introOverlay.style.pointerEvents = 'none';
+  }, 1000);
   setTimeout(() => {
     introOverlay.remove();
-  }, 10100);
+  }, 3000);
 });
 
 // Change button text on mobile

--- a/style.css
+++ b/style.css
@@ -168,6 +168,23 @@ header {
     font-weight: bold;
   }
 
+#intro-card {
+    opacity: 0;
+    margin-top: 20px;
+    width: 225px;
+    pointer-events: none;
+  }
+
+.show-card {
+  animation: fadeInCard 2s forwards;
+  pointer-events: auto;
+}
+
+@keyframes fadeInCard {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
 .show-text {
   animation: fadeInSlow 3s forwards;
 }
@@ -241,5 +258,9 @@ header {
     font-size: 10px;
     width: 20px;
     height: 20px;
+  }
+
+  #intro-card {
+    width: 24%;
   }
 }


### PR DESCRIPTION
## Summary
- Show introductory card image beneath opening text after a short delay and animate its appearance.
- Resize card to 75% of gallery images for desktop and mobile, and fade out overlay only when the card is clicked.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689340d24e288328b72af512eeaa1a1f