### PR TITLE
feat: add follow-up details transition

### DIFF
--- a/script.js
+++ b/script.js
@@ -20,6 +20,20 @@ const introText1 = document.getElementById('intro-text1');
 const introText2 = document.getElementById('intro-text2');
 const introCard = document.getElementById('intro-card');
 const clickTip = document.getElementById('click-tip');
+const additionalData = {
+  '1image': {
+    color: 'rgb(174, 198, 207)',
+    text: `からだを止めて身を守る\n急ブレーキの役割\n背側迷走神経\n止まってるのが\n不安に感じることはありません\n安心して休んで下さい`
+  },
+  '2image': {
+    color: 'rgb(119, 221, 119)',
+    text: `笑顔が増えリラックスしている\n人と繋がろうとする\nチューニングの役割を持った\n腹側迷走神経\nバランスのとれた状態`
+  },
+  '3image': {
+    color: 'rgb(255, 105, 97)',
+    text: `からだを奮い立たせて\nアクセル全開の交感神経\nスピードオーバーに注意して\nゆっくり安心して\n動ける状態を目指します`
+  }
+};
 
 window.addEventListener('DOMContentLoaded', () => {
   setTimeout(() => {
@@ -99,4 +113,34 @@ images.forEach(img => {
 
 closeBtn.addEventListener('click', () => {
   window.location.href = 'index.html';
+});
+
+let detailStage = 'initial';
+moreButton.addEventListener('click', (e) => {
+  if (detailStage !== 'initial') return;
+  e.preventDefault();
+  descriptionDiv.classList.add('fade-up-out');
+  moreButton.classList.add('fade-up-out');
+  setTimeout(() => {
+    descriptionDiv.style.display = 'none';
+    moreButton.style.display = 'none';
+  }, 1000);
+  setTimeout(() => {
+    const imgAlt = currentImg.querySelector('img').alt;
+    const data = additionalData[imgAlt];
+    body.classList.remove('fade-bg');
+    body.style.backgroundColor = data.color;
+    descriptionDiv.innerHTML = data.text.replace(/\n/g, '<br>');
+    descriptionDiv.style.display = 'block';
+    descriptionDiv.classList.remove('fade-up-out');
+    descriptionDiv.classList.add('fade-in-quick');
+    setTimeout(() => {
+      moreButton.textContent = '次へ';
+      moreButton.href = 'index.html';
+      moreButton.style.display = 'inline-block';
+      moreButton.classList.remove('fade-up-out');
+      moreButton.classList.add('fade-in-quick');
+      detailStage = 'next';
+    }, 1000);
+  }, 2000);
 });

--- a/style.css
+++ b/style.css
@@ -3,6 +3,7 @@ body {
   margin: 0;
   padding: 0;
   background: #f5f5f5;
+  transition: background-color 1s;
   text-align: center;
 }
 header {
@@ -127,6 +128,26 @@ header {
 }
 .fade-in-btn {
   animation: fadeInText 3s forwards;
+}
+
+.fade-up-out {
+  animation: fadeUpOut 1s forwards;
+}
+
+.fade-in-quick {
+  animation: fadeInQuick 1s forwards;
+}
+
+@keyframes fadeUpOut {
+  to {
+    opacity: 0;
+    transform: translateY(-20px);
+  }
+}
+
+@keyframes fadeInQuick {
+  from { opacity: 0; }
+  to { opacity: 1; }
 }
 @keyframes fadeInText {
   from { opacity: 0; }


### PR DESCRIPTION
## Summary
- Fade original details and button upward on "More" click
- Show image-specific follow-up text with matching background color
- Reveal "Next" button after transition

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6893576eb2488328ae1a94df722e865c