### PR TITLE
Ensure cards flip to correct images and align properly

### DIFF
--- a/script.js
+++ b/script.js
@@ -102,7 +102,7 @@ function prepareCards() {
   const vh = window.innerHeight;
   images.forEach(card => {
     const img = card.querySelector('img');
-    img.dataset.front = img.src;
+    img.dataset.front = `images/${img.alt}.jpg`;
     img.src = 'images/card.png';
     gsap.set(card, {
       x: (Math.random() - 0.5) * vw,
@@ -256,6 +256,7 @@ images.forEach(img => {
       });
       header.classList.add('hidden');
       window.scrollTo(0, 0);
+      img.style.transform = '';
       img.classList.add('expanded');
       img.appendChild(closeBtn);
       closeBtn.classList.remove('hidden');

--- a/style.css
+++ b/style.css
@@ -23,6 +23,9 @@ header {
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
+  width: 100%;
+  max-width: 960px;
+  flex-wrap: nowrap;
 }
 .image-container {
   position: relative;


### PR DESCRIPTION
## Summary
- Keep revealed cards in a single horizontal row
- Show the correct front images when cards flip
- Center expanded images on mobile devices

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689389f6eda88328b67ca68312ffd82d