### PR TITLE
Blink header subtext without extra tip

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,10 @@
         </div>
         <header>
             <h1>感じあう神経整体</h1>
-            <p class="subtext">からだに意識を向けてクリックしてみてください</p>
+            <p class="subtext">
+                <span class="desktop-text blink">からだに意識を向けてクリックしてみてください</span>
+                <span class="mobile-text blink">からだに意識を向けてタップしてみてください</span>
+            </p>
         </header>
 
         <section class="gallery">

--- a/style.css
+++ b/style.css
@@ -12,6 +12,14 @@ header {
     padding: 20px;
     background: #ccc;
 }
+
+.desktop-text {
+    display: inline;
+}
+
+.mobile-text {
+    display: none;
+}
 .gallery {
     display: flex;
     justify-content: center;
@@ -235,7 +243,8 @@ header {
     font-size: 16px;
 }
 
-#click-tip.blink {
+
+.blink {
     animation: blinkText 2.5s ease-in-out infinite;
 }
 
@@ -337,6 +346,14 @@ header {
         flex-direction: row;
         justify-content: space-between;
         gap: 5px;
+    }
+
+    .desktop-text {
+        display: none;
+    }
+
+    .mobile-text {
+        display: inline;
     }
 
     .image-container {


### PR DESCRIPTION
## Summary
- Remove separate header-tip element from header
- Apply blinking animation directly to desktop and mobile header subtexts
- Drop unused header-tip CSS rule

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689cbc17fd8c8328bb17e536290c0996