### PR TITLE
fix: center gallery images on mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -344,8 +344,15 @@ header {
 @media (max-width: 600px) {
     .gallery {
         flex-direction: row;
-        justify-content: space-between;
+        justify-content: center;
         gap: 5px;
+        margin: 20px auto;
+        width: 100%;
+    }
+
+    .gallery.centered {
+        left: 50%;
+        transform: translate(-50%, -50%);
     }
 
     .desktop-text {


### PR DESCRIPTION
## Summary
- center gallery cards on small screens
- ensure centered layout when image details are shown

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689cc0b194e883289c995b2c3b0b3c8b