### PR TITLE
fix: center intro overlay on mobile

### DIFF
--- a/script.js
+++ b/script.js
@@ -22,6 +22,12 @@ const introText2 = document.getElementById("intro-text2");
 const introCard = document.getElementById("intro-card");
 const clickTip = document.getElementById("click-tip");
 let introPlayed = false;
+function adjustIntroOverlayHeight() {
+  introOverlay.style.height = `${window.innerHeight}px`;
+}
+window.addEventListener("load", adjustIntroOverlayHeight);
+window.addEventListener("resize", adjustIntroOverlayHeight);
+adjustIntroOverlayHeight();
 const additionalData = {
   "1image": {
     color: "rgb(174, 198, 207)",

--- a/style.css
+++ b/style.css
@@ -222,13 +222,19 @@ header {
     top: 0;
     left: 0;
     width: 100%;
-    height: 100%;
+    height: 100vh;
     background: rgb(135, 135, 135);
     display: flex;
     flex-direction: column;
     align-items: center;
     justify-content: center;
     z-index: 100;
+}
+
+@supports (height: 100dvh) {
+    #intro-overlay {
+        height: 100dvh;
+    }
 }
 
 #intro-overlay p {


### PR DESCRIPTION
## Summary
- ensure intro overlay uses viewport height and supports dynamic mobile viewport
- adjust intro overlay height with JS to avoid tap-based repositioning

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689cc2c6e5788328b5c879c53750ea69