### PR TITLE
fix: center intro overlay on mobile

### DIFF
--- a/script.js
+++ b/script.js
@@ -22,6 +22,13 @@ const introText2 = document.getElementById("intro-text2");
 const introCard = document.getElementById("intro-card");
 const clickTip = document.getElementById("click-tip");
 let introPlayed = false;
+function adjustIntroOverlaySize() {
+  introOverlay.style.height = `${window.innerHeight}px`;
+  introOverlay.style.width = `${window.innerWidth}px`;
+}
+window.addEventListener("load", adjustIntroOverlaySize);
+window.addEventListener("resize", adjustIntroOverlaySize);
+adjustIntroOverlaySize();
 const additionalData = {
   "1image": {
     color: "rgb(174, 198, 207)",

--- a/style.css
+++ b/style.css
@@ -221,14 +221,20 @@ header {
     position: fixed;
     top: 0;
     left: 0;
-    width: 100%;
-    height: 100%;
+    width: 100vw;
+    height: 100vh;
     background: rgb(135, 135, 135);
     display: flex;
     flex-direction: column;
     align-items: center;
     justify-content: center;
     z-index: 100;
+}
+
+@supports (height: 100dvh) {
+    #intro-overlay {
+        height: 100dvh;
+    }
 }
 
 #intro-overlay p {


### PR DESCRIPTION
## Summary
- size intro overlay to viewport width so it centers correctly on phones
- set overlay width and height via JS on load and resize to match viewport

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689cc2c6e5788328b5c879c53750ea69