### PR TITLE
feat: add spa-style top page with menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,14 @@
                 <span class="desktop-text blink">からだに意識を向けてクリックしてみてください</span>
                 <span class="mobile-text blink">からだに意識を向けてタップしてみてください</span>
             </p>
+            <nav class="main-menu hidden">
+                <ul>
+                    <li><a href="#" data-section="about">神経整体とは</a></li>
+                    <li><a href="#" data-section="pricing">各種料金</a></li>
+                    <li><a href="#" data-section="contact">お問い合わせ</a></li>
+                    <li><a href="#" id="choose-images">画像を選ぶ</a></li>
+                </ul>
+            </nav>
         </header>
 
         <section class="gallery">
@@ -71,6 +79,21 @@
         </section>
 
         <div class="close-btn hidden">&times;</div>
+
+        <main id="main-content" class="hidden">
+            <section id="about" class="content-section">
+                <h2>神経整体とは</h2>
+                <p>ここに神経整体とはの内容が入ります。</p>
+            </section>
+            <section id="pricing" class="content-section hidden">
+                <h2>各種料金</h2>
+                <p>ここに各種料金の内容が入ります。</p>
+            </section>
+            <section id="contact" class="content-section hidden">
+                <h2>お問い合わせ</h2>
+                <p>ここにお問い合わせの内容が入ります。</p>
+            </section>
+        </main>
 
         <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/gsap.min.js"></script>
         <script src="script.js"></script>

--- a/script.js
+++ b/script.js
@@ -23,6 +23,10 @@ const introText2 = document.getElementById("intro-text2");
 const introCard = document.getElementById("intro-card");
 const clickTip = document.getElementById("click-tip");
 let introPlayed = false;
+const mainMenu = document.querySelector(".main-menu");
+const mainContent = document.getElementById("main-content");
+const contentSections = document.querySelectorAll(".content-section");
+const subtext = document.querySelector(".subtext");
 function adjustIntroOverlaySize() {
   introOverlay.style.height = `${window.innerHeight}px`;
   introOverlay.style.width = `${window.innerWidth}px`;
@@ -378,34 +382,77 @@ closeBtn.addEventListener("click", () => {
   window.location.href = "index.html";
 });
 
+function showSection(id) {
+  contentSections.forEach((sec) => {
+    if (sec.id === id) {
+      sec.classList.remove("hidden");
+    } else {
+      sec.classList.add("hidden");
+    }
+  });
+}
+
+function showTopPage() {
+  details.classList.add("hidden");
+  closeBtn.classList.add("hidden");
+  if (currentImg) currentImg.classList.add("hidden");
+  gallery.classList.add("hidden");
+  body.style.backgroundColor = "";
+  subtext.style.display = "none";
+  mainMenu.classList.remove("hidden");
+  mainContent.classList.remove("hidden");
+  header.classList.remove("hidden");
+  window.scrollTo(0, 0);
+  showSection("about");
+  detailStage = "done";
+}
+
+mainMenu.addEventListener("click", (e) => {
+  const target = e.target;
+  if (target.tagName !== "A") return;
+  e.preventDefault();
+  if (target.id === "choose-images") {
+    window.location.href = "index.html";
+    return;
+  }
+  const section = target.dataset.section;
+  if (section) {
+    showSection(section);
+  }
+});
+
 let detailStage = "initial";
 moreButton.addEventListener("click", (e) => {
-  if (detailStage !== "initial") return;
-  e.preventDefault();
-  descriptionDiv.classList.add("fade-up-out");
-  moreButton.classList.add("fade-up-out");
-  setTimeout(() => {
-    descriptionDiv.style.display = "none";
-    moreButton.style.display = "none";
-  }, 1000);
-  setTimeout(() => {
-    const imgAlt = currentImg.querySelector("img").alt;
-    const data = additionalData[imgAlt];
-    body.classList.remove("fade-bg");
-    body.style.backgroundColor = data.color;
-    descriptionDiv.innerHTML = data.text.replace(/\n/g, "<br>");
-    descriptionDiv.style.display = "block";
-    descriptionDiv.classList.remove("fade-up-out");
-    descriptionDiv.classList.add("fade-in-quick");
+  if (detailStage === "initial") {
+    e.preventDefault();
+    descriptionDiv.classList.add("fade-up-out");
+    moreButton.classList.add("fade-up-out");
     setTimeout(() => {
-      moreButton.textContent = "次へ";
-      moreButton.href = "index.html";
-      moreButton.style.display = "inline-block";
-      moreButton.classList.remove("fade-up-out");
-      moreButton.classList.add("fade-in-quick");
-      autonomicNote.classList.remove("hidden");
-      autonomicNote.classList.add("fade-in-quick");
-      detailStage = "next";
+      descriptionDiv.style.display = "none";
+      moreButton.style.display = "none";
     }, 1000);
-  }, 2000);
+    setTimeout(() => {
+      const imgAlt = currentImg.querySelector("img").alt;
+      const data = additionalData[imgAlt];
+      body.classList.remove("fade-bg");
+      body.style.backgroundColor = data.color;
+      descriptionDiv.innerHTML = data.text.replace(/\n/g, "<br>");
+      descriptionDiv.style.display = "block";
+      descriptionDiv.classList.remove("fade-up-out");
+      descriptionDiv.classList.add("fade-in-quick");
+      setTimeout(() => {
+        moreButton.textContent = "次へ";
+        moreButton.href = "#";
+        moreButton.style.display = "inline-block";
+        moreButton.classList.remove("fade-up-out");
+        moreButton.classList.add("fade-in-quick");
+        autonomicNote.classList.remove("hidden");
+        autonomicNote.classList.add("fade-in-quick");
+        detailStage = "next";
+      }, 1000);
+    }, 2000);
+  } else if (detailStage === "next") {
+    e.preventDefault();
+    showTopPage();
+  }
 });

--- a/style.css
+++ b/style.css
@@ -20,6 +20,24 @@ header {
 .mobile-text {
     display: none;
 }
+
+.main-menu ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    gap: 15px;
+    justify-content: center;
+}
+
+.main-menu a {
+    text-decoration: none;
+    color: #333;
+}
+
+.content-section {
+    padding: 20px;
+}
 .gallery {
     display: flex;
     justify-content: center;


### PR DESCRIPTION
## Summary
- add header menu and content sections to emulate SPA top page
- style menu and content area
- navigate to top page and switch sections without page reload

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1dd9951f883289928e1dabd124161