### PR TITLE
Add skip option for intro animation

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
             <p id="intro-text2">手を当ててみて下さい</p>
             <img id="intro-card" src="images/card.png" alt="card" />
             <p id="click-tip"></p>
+            <p id="skip-button">スキップ</p>
         </div>
         <header>
             <h1>感じあう神経整体</h1>

--- a/script.js
+++ b/script.js
@@ -22,6 +22,7 @@ const introText1 = document.getElementById("intro-text1");
 const introText2 = document.getElementById("intro-text2");
 const introCard = document.getElementById("intro-card");
 const clickTip = document.getElementById("click-tip");
+const skipButton = document.getElementById("skip-button");
 let introPlayed = false;
 const mainMenu = document.querySelector(".main-menu");
 const mainContent = document.getElementById("main-content");
@@ -282,6 +283,8 @@ const introSequence = [
         : "※画像をクリック";
       clickTip.textContent = tipText;
       clickTip.classList.add("blink");
+      skipButton.classList.add("show-text");
+      skipButton.style.pointerEvents = "auto";
     },
     finish: () => {},
     delay: 0,
@@ -312,6 +315,14 @@ introOverlay.addEventListener("click", (e) => {
   step.finish();
   introStep++;
   playIntroStep();
+});
+
+skipButton.addEventListener("click", (e) => {
+  e.stopPropagation();
+  clearTimeout(introTimer);
+  introStep = introSequence.length;
+  introOverlay.remove();
+  showTopPage();
 });
 
 introCard.addEventListener("click", () => {

--- a/style.css
+++ b/style.css
@@ -274,6 +274,13 @@ header {
     font-size: 16px;
 }
 
+#skip-button {
+    font-size: 16px;
+    cursor: pointer;
+    text-decoration: underline;
+    pointer-events: none;
+}
+
 
 .blink {
     animation: blinkText 2.5s ease-in-out infinite;


### PR DESCRIPTION
## Summary
- show a "スキップ" link under the intro click/tap tip
- allow skipping directly to the "神経整体とは" section

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1e1fb10908328a36f60a37049d93f