### PR TITLE
Embed responsive YouTube video

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,6 +85,9 @@
             <section id="about" class="content-section">
                 <h2>神経整体とは？</h2>
                 <p>まずは動画をチェックする</p>
+                <div class="video-container">
+                    <iframe src="https://www.youtube.com/embed/8r2Id9-0Rrs?si=AE72ei4M4VvF0FEv" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+                </div>
             </section>
             <section id="pricing" class="content-section hidden">
                 <h2>各種料金</h2>

--- a/style.css
+++ b/style.css
@@ -38,6 +38,22 @@ header {
 .content-section {
     padding: 20px;
 }
+.video-container {
+    position: relative;
+    width: 100%;
+    max-width: 800px;
+    margin: 20px auto;
+    padding-bottom: 56.25%;
+    height: 0;
+    overflow: hidden;
+}
+.video-container iframe {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+}
 .gallery {
     display: flex;
     justify-content: center;


### PR DESCRIPTION
## Summary
- Add a YouTube iframe to the "神経整体とは" section and display it beneath the introductory text
- Add responsive styling so the embedded video scales cleanly on desktop and mobile

## Testing
- ⚠️ `npm test` *(missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1e4c82d648328a4c7cb5f56713ec3