### PR TITLE
Implement hamburger menu for mobile header

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@
         </div>
         <header>
             <h1>感じあう神経整体</h1>
+            <button class="hamburger" aria-label="メニュー">&#9776;</button>
             <p class="subtext">
                 <span class="desktop-text blink">からだに意識を向けてクリックしてみてください</span>
                 <span class="mobile-text blink">からだに意識を向けてタップしてみてください</span>

--- a/script.js
+++ b/script.js
@@ -25,6 +25,10 @@ const clickTip = document.getElementById("click-tip");
 const skipButton = document.getElementById("skip-button");
 let introPlayed = false;
 const mainMenu = document.querySelector(".main-menu");
+const hamburger = document.querySelector(".hamburger");
+hamburger.addEventListener("click", () => {
+  mainMenu.classList.toggle("open");
+});
 const mainContent = document.getElementById("main-content");
 const contentSections = document.querySelectorAll(".content-section");
 const subtext = document.querySelector(".subtext");
@@ -422,6 +426,7 @@ mainMenu.addEventListener("click", (e) => {
   const target = e.target;
   if (target.tagName !== "A") return;
   e.preventDefault();
+  mainMenu.classList.remove("open");
   if (target.id === "choose-images") {
     window.location.href = "index.html";
     return;

--- a/style.css
+++ b/style.css
@@ -11,6 +11,7 @@ body {
 header {
     padding: 20px;
     background: #ccc;
+    position: relative;
 }
 
 .desktop-text {
@@ -19,6 +20,14 @@ header {
 
 .mobile-text {
     display: none;
+}
+
+.hamburger {
+    display: none;
+    background: none;
+    border: none;
+    font-size: 24px;
+    cursor: pointer;
 }
 
 .main-menu ul {
@@ -396,6 +405,38 @@ header {
 
 /* Responsive styles */
 @media (max-width: 600px) {
+    .hamburger {
+        display: block;
+        position: absolute;
+        top: 20px;
+        right: 20px;
+        background: none;
+        border: none;
+        font-size: 24px;
+        cursor: pointer;
+    }
+
+    .main-menu {
+        display: none;
+        background: #ccc;
+        position: absolute;
+        top: 60px;
+        right: 20px;
+        padding: 10px;
+        border-radius: 4px;
+    }
+
+    .main-menu.open {
+        display: block;
+    }
+
+    .main-menu ul {
+        flex-direction: column;
+        gap: 10px;
+        justify-content: flex-start;
+        align-items: flex-start;
+    }
+
     .gallery {
         flex-direction: row;
         justify-content: center;


### PR DESCRIPTION
## Summary
- Add hamburger button to header for mobile devices
- Hide and toggle navigation menu via CSS and JavaScript
- Adjust styles so mobile layout uses vertical menu

## Testing
- `npm test` *(fails: /usr/bin/npm: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a1e7b304e08328a164419dedf38255