### PR TITLE
Remove close buttons and delay mobile menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
         </div>
         <header>
             <h1>感じあう神経整体</h1>
-            <button class="hamburger" aria-label="メニュー">&#9776;</button>
+            <button class="hamburger hidden" aria-label="メニュー">&#9776;</button>
             <p class="subtext">
                 <span class="desktop-text blink">からだに意識を向けてクリックしてみてください</span>
                 <span class="mobile-text blink">からだに意識を向けてタップしてみてください</span>
@@ -79,8 +79,6 @@
                 とらえてみましょう
             </p>
         </section>
-
-        <div class="close-btn hidden">&times;</div>
 
         <main id="main-content" class="hidden">
             <section id="about" class="content-section">

--- a/script.js
+++ b/script.js
@@ -12,7 +12,6 @@ const images = document.querySelectorAll(".image-container");
 let cardsClickable = false;
 const details = document.querySelector(".details");
 const descriptionDiv = document.querySelector(".description");
-const closeBtn = document.querySelector(".close-btn");
 const body = document.body;
 const header = document.querySelector("header");
 const moreButton = document.querySelector(".more-button");
@@ -346,6 +345,7 @@ introCard.addEventListener("click", () => {
     playCardBurst(() => {
       // ← この段階で30枚を消す
       header.style.visibility = "visible";
+      hamburger.classList.remove("hidden");
       animateCards(); // ← 3枚を整列
       setTimeout(flipCardsToFront, 2000); // ← 表にめくる
     });
@@ -377,8 +377,6 @@ images.forEach((img) => {
       window.scrollTo(0, 0);
       img.style.transform = "";
       img.classList.add("expanded");
-      img.appendChild(closeBtn);
-      closeBtn.classList.remove("hidden");
       body.classList.add("fade-bg");
       setTimeout(() => {
         img.classList.add("dim-image");
@@ -393,9 +391,6 @@ images.forEach((img) => {
   });
 });
 
-closeBtn.addEventListener("click", () => {
-  window.location.href = "index.html";
-});
 
 function showSection(id) {
   contentSections.forEach((sec) => {
@@ -409,7 +404,6 @@ function showSection(id) {
 
 function showTopPage() {
   details.classList.add("hidden");
-  closeBtn.classList.add("hidden");
   if (currentImg) currentImg.classList.add("hidden");
   gallery.classList.add("hidden");
   body.style.backgroundColor = "";
@@ -417,6 +411,7 @@ function showTopPage() {
   mainMenu.classList.remove("hidden");
   mainContent.classList.remove("hidden");
   header.classList.remove("hidden");
+  hamburger.classList.remove("hidden");
   window.scrollTo(0, 0);
   showSection("about");
   detailStage = "done";

--- a/style.css
+++ b/style.css
@@ -168,22 +168,6 @@ header {
     white-space: nowrap;
 }
 
-.close-btn {
-    position: fixed;
-    top: 10px;
-    right: 10px;
-    z-index: 30;
-    font-size: 24px;
-    width: 40px;
-    height: 40px;
-    border-radius: 50%;
-    background: rgba(0, 0, 0, 0.5);
-    color: #fff;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    cursor: pointer;
-}
 /* New animations */
 .fade-out-other {
     animation: fadeOut 0.5s forwards;
@@ -259,12 +243,6 @@ header {
     text-align: center;
     word-break: break-word;
     overflow-wrap: anywhere;
-}
-.image-container .close-btn {
-    position: absolute;
-    top: 5px;
-    right: 5px;
-    z-index: 30;
 }
 
 #intro-overlay {
@@ -503,11 +481,6 @@ header {
         padding: 3px 6px;
     }
 
-    .close-btn {
-        font-size: 10px;
-        width: 20px;
-        height: 20px;
-    }
 
     #intro-card {
         width: 24%;


### PR DESCRIPTION
## Summary
- Remove top-right close button and associated styles and scripts
- Keep mobile hamburger hidden during intro, revealing it once animations finish

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1ea374f688328ab6c8a1abd8a85ea