### PR TITLE
Enhance menu hover and mobile overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,8 +98,9 @@
             </section>
         </main>
 
+        <div id="menu-overlay" class="hidden"></div>
+        <div id="white-overlay"></div>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/gsap.min.js"></script>
         <script src="script.js"></script>
-        <div id="white-overlay"></div>
     </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -25,8 +25,18 @@ const skipButton = document.getElementById("skip-button");
 let introPlayed = false;
 const mainMenu = document.querySelector(".main-menu");
 const hamburger = document.querySelector(".hamburger");
+const menuOverlay = document.getElementById("menu-overlay");
 hamburger.addEventListener("click", () => {
-  mainMenu.classList.toggle("open");
+  const isOpen = mainMenu.classList.toggle("open");
+  if (isOpen) {
+    menuOverlay.classList.remove("hidden");
+  } else {
+    menuOverlay.classList.add("hidden");
+  }
+});
+menuOverlay.addEventListener("click", () => {
+  mainMenu.classList.remove("open");
+  menuOverlay.classList.add("hidden");
 });
 const mainContent = document.getElementById("main-content");
 const contentSections = document.querySelectorAll(".content-section");
@@ -408,6 +418,7 @@ function showTopPage() {
   gallery.classList.add("hidden");
   body.style.backgroundColor = "";
   subtext.style.display = "none";
+  menuOverlay.classList.add("hidden");
   mainMenu.classList.remove("hidden");
   mainContent.classList.remove("hidden");
   header.classList.remove("hidden");
@@ -422,6 +433,7 @@ mainMenu.addEventListener("click", (e) => {
   if (target.tagName !== "A") return;
   e.preventDefault();
   mainMenu.classList.remove("open");
+  menuOverlay.classList.add("hidden");
   if (target.id === "choose-images") {
     window.location.href = "index.html";
     return;

--- a/style.css
+++ b/style.css
@@ -42,6 +42,14 @@ header {
 .main-menu a {
     text-decoration: none;
     color: #333;
+    padding: 5px 10px;
+    border-radius: 4px;
+    transition: background-color 0.5s ease, color 0.5s ease;
+}
+
+.main-menu a:hover {
+    background-color: #eee;
+    color: #000;
 }
 
 .content-section {
@@ -392,6 +400,7 @@ header {
         border: none;
         font-size: 24px;
         cursor: pointer;
+        z-index: 1001;
     }
 
     .main-menu {
@@ -402,10 +411,21 @@ header {
         right: 20px;
         padding: 10px;
         border-radius: 4px;
+        z-index: 1000;
     }
 
     .main-menu.open {
         display: block;
+    }
+
+    #menu-overlay {
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background: rgba(0, 0, 0, 0.5);
+        z-index: 500;
     }
 
     .main-menu ul {


### PR DESCRIPTION
## Summary
- add smooth hover highlight for desktop header links
- dim background when mobile hamburger menu is open

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1f65182c48328b2dabe205c6d8e72