### PR TITLE
Fix mobile hamburger menu showing before intro ends

### DIFF
--- a/style.css
+++ b/style.css
@@ -403,6 +403,10 @@ header {
         z-index: 1001;
     }
 
+    .hamburger.hidden {
+        display: none;
+    }
+
     .main-menu {
         display: none;
         background: #ccc;


### PR DESCRIPTION
## Summary
- hide hamburger menu on mobile during intro by adding `.hamburger.hidden` rule so it appears only after animation finishes

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1f8c3b29883288a9b76146afac924