### PR TITLE
Fix mobile hamburger visibility after intro

### DIFF
--- a/script.js
+++ b/script.js
@@ -355,7 +355,6 @@ introCard.addEventListener("click", () => {
     playCardBurst(() => {
       // ← この段階で30枚を消す
       header.style.visibility = "visible";
-      hamburger.classList.remove("hidden");
       animateCards(); // ← 3枚を整列
       setTimeout(flipCardsToFront, 2000); // ← 表にめくる
     });


### PR DESCRIPTION
## Summary
- Remove hamburger reveal after card flip sequence
- Show hamburger only after displaying the '神経整体とは?' section via Next button

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1fadbd54c8328b3d00f2056f5d8cb