### PR TITLE
Show detail texts with Next button and match fonts

### DIFF
--- a/script.js
+++ b/script.js
@@ -464,23 +464,20 @@ moreButton.addEventListener("click", (e) => {
       body.classList.remove("fade-bg");
       body.style.backgroundColor = data.color;
       descriptionDiv.innerHTML = data.text.replace(/\n/g, "<br>");
+      moreButton.textContent = "次へ";
+      moreButton.href = "#";
+      autonomicNote.classList.remove("hidden");
+      details.insertBefore(autonomicNote, moreButton);
+      details.appendChild(descriptionDiv);
+      autonomicNote.style.marginTop = "0";
+      descriptionDiv.style.marginTop = "10px";
       descriptionDiv.style.display = "block";
-      descriptionDiv.classList.remove("fade-up-out");
-      descriptionDiv.classList.add("fade-in-quick");
-      setTimeout(() => {
-        moreButton.textContent = "次へ";
-        moreButton.href = "#";
-        moreButton.style.display = "inline-block";
-        moreButton.classList.remove("fade-up-out");
-        moreButton.classList.add("fade-in-quick");
-        autonomicNote.classList.remove("hidden");
-        autonomicNote.classList.add("fade-in-quick");
-        details.insertBefore(autonomicNote, moreButton);
-        details.appendChild(descriptionDiv);
-        autonomicNote.style.marginTop = "0";
-        descriptionDiv.style.marginTop = "10px";
-        detailStage = "next";
-      }, 1000);
+      moreButton.style.display = "inline-block";
+      [descriptionDiv, moreButton, autonomicNote].forEach((el) => {
+        el.classList.remove("fade-up-out");
+        el.classList.add("fade-in-quick");
+      });
+      detailStage = "next";
     }, 2000);
   } else if (detailStage === "next") {
     e.preventDefault();

--- a/style.css
+++ b/style.css
@@ -247,6 +247,7 @@ header {
 }
 .autonomic-note {
     font-size: 10px;
+    font-weight: bold;
     margin-top: 10px;
     text-align: center;
     word-break: break-word;
@@ -495,6 +496,7 @@ header {
 
     .autonomic-note {
         font-size: 7px;
+        font-weight: bold;
         text-align: center;
         word-break: break-word;
     }


### PR DESCRIPTION
## Summary
- Show both detail texts simultaneously with the Next button
- Apply bold weight to autonomic-note so its font matches the lower text

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b445b9d7908328baffa39859fb1752