### PR TITLE
Add colored circle transition before navigating to about section

### DIFF
--- a/script.js
+++ b/script.js
@@ -262,6 +262,48 @@ function showWhiteOverlay() {
   });
 }
 
+function playTransitionAnimation() {
+  return new Promise((resolve) => {
+    const overlay = document.createElement("div");
+    overlay.id = "transition-overlay";
+    document.body.appendChild(overlay);
+
+    const colors = ["red", "green", "blue"];
+    const circles = colors.map((color) => {
+      const div = document.createElement("div");
+      div.className = `color-circle ${color}`;
+      overlay.appendChild(div);
+      return div;
+    });
+
+    const positions = [
+      { top: "50%", left: "20%" },
+      { top: "20%", left: "80%" },
+      { top: "80%", left: "80%" },
+    ];
+    positions.forEach((pos, i) => {
+      gsap.set(circles[i], { ...pos, xPercent: -50, yPercent: -50 });
+    });
+
+    const tl = gsap.timeline({
+      onComplete: () => {
+        overlay.remove();
+        resolve();
+      },
+    });
+
+    tl.to(overlay, { backgroundColor: "#808080", duration: 1 }, 0);
+    tl.to(circles, { opacity: 1, duration: 1 }, 0);
+    tl.to(circles, { top: "50%", left: "50%", duration: 1 }, ">" );
+    tl.to(overlay, { backgroundColor: "#ffffff", duration: 1 }, ">" );
+    tl.to(circles, { opacity: 0, duration: 1 }, "<");
+    tl.add(() => {
+      showTopPage();
+    });
+    tl.to(overlay, { opacity: 0, duration: 0.5 }, ">" );
+  });
+}
+
 // Intro sequence with skip-on-click functionality
 const introSequence = [
   {
@@ -481,6 +523,7 @@ moreButton.addEventListener("click", (e) => {
     }, 2000);
   } else if (detailStage === "next") {
     e.preventDefault();
-    showTopPage();
+    moreButton.style.pointerEvents = "none";
+    playTransitionAnimation();
   }
 });

--- a/style.css
+++ b/style.css
@@ -390,6 +390,38 @@ header {
     z-index: 999;
 }
 
+#transition-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: transparent;
+    pointer-events: none;
+    z-index: 1000;
+}
+
+.color-circle {
+    position: absolute;
+    width: 150px;
+    height: 150px;
+    border-radius: 50%;
+    mix-blend-mode: screen;
+    opacity: 0;
+}
+
+.color-circle.red {
+    background: red;
+}
+
+.color-circle.green {
+    background: green;
+}
+
+.color-circle.blue {
+    background: blue;
+}
+
 /* Responsive styles */
 @media (max-width: 600px) {
     .hamburger {


### PR DESCRIPTION
## Summary
- Implement transition animation after "次へ" with grey fade, red/green/blue circles, blend overlap, and white-out
- Style overlay and circles with mix-blend-mode to create white center blend
- Hook animation to "次へ" button to navigate to the 神経整体とは section

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b450edb42c8328b3f9e2e9873a972e