### PR TITLE
Fix desktop video aspect ratio

### DIFF
--- a/style.css
+++ b/style.css
@@ -60,14 +60,9 @@ header {
     width: 100%;
     max-width: 800px;
     margin: 20px auto;
-    padding-bottom: 56.25%;
-    height: 0;
-    overflow: hidden;
+    aspect-ratio: 16 / 9;
 }
 .video-container iframe {
-    position: absolute;
-    top: 0;
-    left: 0;
     width: 100%;
     height: 100%;
 }


### PR DESCRIPTION
## Summary
- Ensure desktop video embeds use a 16:9 aspect ratio for natural YouTube sizing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5a9ef6538832885c569707eede061