### PR TITLE
Adjust modal layout for mobile viewports

### DIFF
--- a/style.css
+++ b/style.css
@@ -230,6 +230,18 @@ header {
     position: relative;
     overflow-y: auto;
     -webkit-overflow-scrolling: touch;
+    box-sizing: border-box;
+}
+
+@media (max-width: 600px) {
+    .modal {
+        padding: 12px;
+    }
+
+    .modal-content {
+        padding: 24px 18px;
+        width: min(100%, 520px);
+    }
 }
 
 .modal-text {


### PR DESCRIPTION
## Summary
- ensure the journey modal's content uses border-box sizing so its padding no longer causes horizontal overflow
- tighten modal padding on small screens to keep the popup within the viewport

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e081f451c0832888c5283491c0534f