### PR TITLE
Allow navigation from modal to menu sections

### DIFF
--- a/script.js
+++ b/script.js
@@ -123,12 +123,13 @@ function openModal(stepIndex = 0) {
   body.classList.add("modal-open");
 }
 
-function closeModal() {
-  if (!modalOverlay) return;
+function closeModal(options = {}) {
+  const { restoreFocus = true } = options;
+  if (!modalOverlay || modalOverlay.classList.contains("hidden")) return;
   modalOverlay.classList.add("hidden");
   modalOverlay.setAttribute("aria-hidden", "true");
   body.classList.remove("modal-open");
-  if (startButton) {
+  if (restoreFocus && startButton) {
     startButton.focus();
   }
 }
@@ -595,6 +596,7 @@ mainMenu.addEventListener("click", (e) => {
     window.location.href = "index.html";
     return;
   }
+  closeModal({ restoreFocus: false });
   const section = target.dataset.section;
   if (section) {
     showSection(section);


### PR DESCRIPTION
## Summary
- allow the journey modal to close without restoring focus when navigating
- close the modal when a hamburger menu link is chosen so sections can change

## Testing
- Manual testing in browser

------
https://chatgpt.com/codex/tasks/task_e_68e0891fc918832897369037c14f1f32